### PR TITLE
fix: Corregir configuración PostCSS y Next.js para Vercel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,21 +26,7 @@ const nextConfig = {
   },
   
   // Optimización para mobile - evitar JavaScript legacy
-  swcMinify: true,
-  
-  // Configuración de browserslist para evitar transpilación legacy
-  browserslist: {
-    production: [
-      '>0.2%',
-      'not dead',
-      'not op_mini all'
-    ],
-    development: [
-      'last 1 chrome version',
-      'last 1 firefox version',
-      'last 1 safari version'
-    ]
-  },
+  // swcMinify ya está habilitado por defecto en Next.js 15
   
   // Optimización de bundle
   experimental: {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,11 +1,9 @@
-const purgecss = require('@fullhuman/postcss-purgecss')
-
 module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
     ...(process.env.NODE_ENV === 'production' ? {
-      [require.resolve('@fullhuman/postcss-purgecss')]: {
+      '@fullhuman/postcss-purgecss': {
         content: [
           './pages/**/*.{js,ts,jsx,tsx}',
           './components/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
 Correcciones aplicadas:
- PostCSS: Sintaxis correcta para PurgeCSS plugin
- Next.js: Removidas configuraciones incompatibles con v15
- swcMinify: Ya habilitado por defecto en Next.js 15
- browserslist: Removido (no compatible con Next.js config)

 Compatibilidad:
- Next.js 15.5.3
- PostCSS con PurgeCSS
- Vercel build process

Fixes build errors en Vercel deployment